### PR TITLE
undefined method `class_inheritable_accessor' for Rails 3.2 its depricated

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -177,7 +177,7 @@ module Technoweenie # :nodoc:
       end
 
       def self.extended(base)
-        base.class_inheritable_accessor :attachment_options
+        base.class_attribute :attachment_options
         base.before_destroy :destroy_thumbnails
         base.before_validation :set_size_from_temp_path
         base.after_save :after_process_attachment


### PR DESCRIPTION
undefined method `class_inheritable_accessor' for Rails 3.2 its depricated
Changed with class_attribute.
